### PR TITLE
Ferry support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,11 +358,11 @@ target/
 .DS_Store
 .project
 .pydevproject
-.vscode/settings.json
+.vscode
 
 # Virtual environment
 venv/
 # Test purpose only
 ferry_test.py
-Exempel_svar
-.vscode/launch.json
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ target/
 .project
 .pydevproject
 .vscode/settings.json
+
+# Virtual environment
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,7 @@ target/
 
 # Virtual environment
 venv/
+# Test purpose only
+ferry_test.py
+Exempel_svar
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -364,5 +364,3 @@ target/
 venv/
 # Test purpose only
 ferry_test.py
-
-

--- a/README.md
+++ b/README.md
@@ -32,4 +32,6 @@ loop.run_until_complete(main(loop))
 $ py pytrafikverket.py -key [api_key_here] -method search-for-station -station "Kristianstad"
 $ py pytrafikverket.py -key [api_key_here] -method get-next-train-stop -from-station "Kristianstad C" -to-station "Sölvesborg"
 $ py pytrafikverket.py -key [api_key_here] -method get-train-stop -from-station "Kristianstad C" -to-station "Sölvesborg" -date-time "2017-05-19T16:38:00"
+$ py pytrafikverket.py -key [api_key_here] -method get-next-ferry-stop -from-harbor "Ekerö" 
+$ py pytrafikverket.py -key [api_key_here] -method get-next-ferry-stop -from-harbor "Furusund" -date-time "2019-12-24T00:00:00"
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ loop.run_until_complete(main(loop))
 $ py pytrafikverket.py -key [api_key_here] -method search-for-station -station "Kristianstad"
 $ py pytrafikverket.py -key [api_key_here] -method get-next-train-stop -from-station "Kristianstad C" -to-station "Sölvesborg"
 $ py pytrafikverket.py -key [api_key_here] -method get-train-stop -from-station "Kristianstad C" -to-station "Sölvesborg" -date-time "2017-05-19T16:38:00"
+$ py pytrafikverket.py -key [api_key_here] -method search-for-ferry-route -route "sund"
+$ py pytrafikverket.py -key [api_key_here] -method get-ferry-route -route "Adelsöleden"
 $ py pytrafikverket.py -key [api_key_here] -method get-next-ferry-stop -from-harbor "Ekerö" 
 $ py pytrafikverket.py -key [api_key_here] -method get-next-ferry-stop -from-harbor "Furusund" -date-time "2019-12-24T00:00:00"
 ```

--- a/pytrafikverket/__init__.py
+++ b/pytrafikverket/__init__.py
@@ -7,4 +7,4 @@ from pytrafikverket.trafikverket_train import (StationInfo, TrafikverketTrain,
 from pytrafikverket.trafikverket_weather import (TrafikverketWeather,
                                                  WeatherStationInfo)
 from pytrafikverket.trafikverket_ferry import (TrafikverketFerry,
-                                                 FerryStop, FerryStopStatus)
+                                               FerryStop, FerryStopStatus)

--- a/pytrafikverket/__init__.py
+++ b/pytrafikverket/__init__.py
@@ -1,4 +1,5 @@
 """Pytrafikverket module."""
+# flake8: noqa
 from pytrafikverket.trafikverket import (AndFilter, FieldFilter, FieldSort,
                                          Filter, FilterOperation, NodeHelper,
                                          OrFilter, SortOrder, Trafikverket)

--- a/pytrafikverket/__init__.py
+++ b/pytrafikverket/__init__.py
@@ -6,3 +6,5 @@ from pytrafikverket.trafikverket_train import (StationInfo, TrafikverketTrain,
                                                TrainStop, TrainStopStatus)
 from pytrafikverket.trafikverket_weather import (TrafikverketWeather,
                                                  WeatherStationInfo)
+from pytrafikverket.trafikverket_ferry import (TrafikverketFerry,
+                                                 FerryStop, FerryStopStatus)

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -16,8 +16,8 @@ SEARCH_FOR_STATION = "search-for-station"
 GET_TRAIN_STOP = "get-train-stop"
 GET_NEXT_TRAIN_STOP = "get-next-train-stop"
 GET_WEATHER = "get-weather"
-GET_ROUTE = "get-route"
-SEARCH_FOR_ROUTE = "search-for-route"
+GET_FERRY_ROUTE = "get-ferry-route"
+SEARCH_FOR_FERRY_ROUTE = "search-for-ferry-route"
 GET_NEXT_FERRY_STOP = "get-next-ferry-stop"
 
 
@@ -35,8 +35,8 @@ async def async_main(loop):
                 GET_TRAIN_STOP,
                 GET_NEXT_TRAIN_STOP,
                 GET_WEATHER,
-                GET_ROUTE,
-                SEARCH_FOR_ROUTE,
+                GET_FERRY_ROUTE,
+                SEARCH_FOR_FERRY_ROUTE,
                 GET_NEXT_FERRY_STOP,
             ),
         )
@@ -103,19 +103,19 @@ async def async_main(loop):
                 weather = await weather_api.async_get_weather(args.station)
                 print_values(weather)
 
-            elif args.method == GET_ROUTE:
+            elif args.method == GET_FERRY_ROUTE:
                 if args.route is None:
                     raise ValueError(
                         '-route is required with name of Ferry route\
                          (ex. -route "Ekeröleden")'
                     )
-                route = await ferry_api.async_get_route(args.route)
+                route = await ferry_api.async_get_ferry_route(args.route)
                 print_values(route)
 
-            elif args.method == SEARCH_FOR_ROUTE:
+            elif args.method == SEARCH_FOR_FERRY_ROUTE:
                 if args.route is None:
                     raise ValueError("-route is required")
-                routes = await ferry_api.async_search_routes(args.route)
+                routes = await ferry_api.async_search_ferry_routes(args.route)
                 for route in routes:
                     print_values(route)
                     print(route.name + " " + route.id)

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -140,6 +140,7 @@ async def async_main(loop):
 
 
 def print_values(object):
+    """Print out values for all object members."""
     for i in inspect.getmembers(object):
         if not i[0].startswith("_"):
             if not inspect.ismethod(i[1]):

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -8,89 +8,140 @@ import async_timeout
 from pytrafikverket.trafikverket import Trafikverket
 from pytrafikverket.trafikverket_train import TrafikverketTrain
 from pytrafikverket.trafikverket_weather import TrafikverketWeather
+from pytrafikverket.trafikverket_ferry import TrafikverketFerry
 import inspect
+
 
 SEARCH_FOR_STATION = "search-for-station"
 GET_TRAIN_STOP = "get-train-stop"
 GET_NEXT_TRAIN_STOP = "get-next-train-stop"
 GET_WEATHER = "get-weather"
+GET_ROUTE = "get-route"
+SEARCH_FOR_ROUTE = "search-for-route"
+GET_NEXT_FERRY_STOP = "get-next-ferry-stop"
 
 
 async def async_main(loop):
     """Set up function to handle input and get data to present."""
     async with aiohttp.ClientSession(loop=loop) as session:
         parser = argparse.ArgumentParser(
-            description="CLI used to get data from trafikverket")
+            description="CLI used to get data from trafikverket"
+        )
         parser.add_argument("-key", type=str)
-        parser.add_argument("-method", choices=(SEARCH_FOR_STATION,
-                                                GET_TRAIN_STOP,
-                                                GET_NEXT_TRAIN_STOP,
-                                                GET_WEATHER))
+        parser.add_argument(
+            "-method",
+            choices=(
+                SEARCH_FOR_STATION,
+                GET_TRAIN_STOP,
+                GET_NEXT_TRAIN_STOP,
+                GET_WEATHER,
+                GET_ROUTE,
+                SEARCH_FOR_ROUTE,
+                GET_NEXT_FERRY_STOP,
+            ),
+        )
         parser.add_argument("-station", type=str)
         parser.add_argument("-from-station", type=str)
         parser.add_argument("-to-station", type=str)
         parser.add_argument("-date-time", type=str)
+        parser.add_argument("-route", type=str)
+        parser.add_argument("-from-harbor", type=str)
+        parser.add_argument("-to-harbor", type=str)
 
         args = parser.parse_args()
 
         train_api = TrafikverketTrain(session, args.key)
         weather_api = TrafikverketWeather(session, args.key)
+        ferry_api = TrafikverketFerry(session, args.key)
         with async_timeout.timeout(10):
             if args.method == SEARCH_FOR_STATION:
                 if args.station is None:
                     raise ValueError("-station is required")
-                stations = await train_api.async_search_train_stations(
-                                  args.station)
+                stations = await train_api.async_search_train_stations(args.station)
                 for station in stations:
                     print(station.name + " " + station.signature)
             elif args.method == GET_TRAIN_STOP:
                 from_station = await train_api.async_get_train_station(
-                                      args.from_station)
-                to_station = await train_api.async_get_train_station(
-                                    args.to_station)
+                    args.from_station
+                )
+                to_station = await train_api.async_get_train_station(args.to_station)
                 print("from_station_signature: " + from_station.signature)
                 print("to_station_signature:   " + to_station.signature)
 
-                time = datetime.strptime(
-                        args.date_time,
-                        Trafikverket.date_time_format)
+                time = datetime.strptime(args.date_time, Trafikverket.date_time_format)
 
                 train_stop = await train_api.async_get_train_stop(
-                                    from_station,
-                                    to_station, time)
+                    from_station, to_station, time
+                )
                 print_values(train_stop)
 
             elif args.method == GET_NEXT_TRAIN_STOP:
                 from_station = await train_api.async_get_train_station(
-                                      args.from_station)
-                to_station = await train_api.async_get_train_station(
-                                    args.to_station)
+                    args.from_station
+                )
+                to_station = await train_api.async_get_train_station(args.to_station)
                 print("from_station_signature: " + from_station.signature)
                 print("to_station_signature:   " + to_station.signature)
 
                 if args.date_time is not None:
                     time = datetime.strptime(
-                            args.date_time,
-                            Trafikverket.date_time_format)
+                        args.date_time, Trafikverket.date_time_format
+                    )
                 else:
                     time = datetime.now()
                 train_stop = await train_api.async_get_next_train_stop(
-                                    from_station,
-                                    to_station,
-                                    time)
+                    from_station, to_station, time
+                )
                 print_values(train_stop)
 
             elif args.method == GET_WEATHER:
                 if args.station is None:
                     raise ValueError(
-                        "-station is required with name of Weather station\
-                         (ex. -station \"Nöbbele\")")
+                        '-station is required with name of Weather station\
+                         (ex. -station "Nöbbele")'
+                    )
                 weather = await weather_api.async_get_weather(args.station)
                 print_values(weather)
 
+            elif args.method == GET_ROUTE:
+                if args.route is None:
+                    raise ValueError(
+                        '-route is required with name of Ferry route\
+                         (ex. -route "Ekeröleden")'
+                    )
+                route = await ferry_api.async_get_route(args.route)
+                print_values(route)
+
+            elif args.method == SEARCH_FOR_ROUTE:
+                if args.route is None:
+                    raise ValueError("-route is required")
+                routes = await ferry_api.async_search_routes(args.route)
+                for route in routes:
+                    print_values(route)
+                    print(route.name + " " + route.id)
+
+            elif args.method == GET_NEXT_FERRY_STOP:
+                if args.from_station is None:
+                    raise ValueError(
+                        '-from-harbor is required with name of Ferry harbor\
+                         (ex. -from-harbor "Ekerö")'
+                    )
+                if args.date_time is not None:
+                    time = datetime.strptime(
+                        args.date_time, Trafikverket.date_time_format
+                    )
+                else:
+                    time = datetime.now()
+
+                ferry_stop = await ferry_api.async_get_next_ferry_stop(
+                    args.from_harbor, args.to_harbor, time
+                )
+                print_values(ferry_stop)
+
+
 def print_values(object):
     for i in inspect.getmembers(object):
-        if not i[0].startswith('_'):
+        if not i[0].startswith("_"):
             if not inspect.ismethod(i[1]):
                 print(i[0], "=", i[1])
 

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -27,9 +27,9 @@ async def async_main(loop):
         parser = argparse.ArgumentParser(
             description="CLI used to get data from trafikverket"
         )
-        parser.add_argument("-key", type=str)
+        parser.add_argument("-key", type=str, required=True)
         parser.add_argument(
-            "-method",
+            "-method", required=True,
             choices=(
                 SEARCH_FOR_STATION,
                 GET_TRAIN_STOP,

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -121,7 +121,7 @@ async def async_main(loop):
                     print(route.name + " " + route.id)
 
             elif args.method == GET_NEXT_FERRY_STOP:
-                if args.from_station is None:
+                if args.from_harbor is None:
                     raise ValueError(
                         '-from-harbor is required with name of Ferry harbor\
                          (ex. -from-harbor "Ekerö")'

--- a/pytrafikverket/trafikverket.py
+++ b/pytrafikverket/trafikverket.py
@@ -89,7 +89,7 @@ class AndFilter(Filter):
 class Trafikverket(object):
     """Class used to communicate with trafikverket api"""
 
-    _api_url = "http://api.trafikinfo.trafikverket.se/v1.3/data.xml"
+    _api_url = "http://api.trafikinfo.trafikverket.se/v1.2/data.xml"
     date_time_format = "%Y-%m-%dT%H:%M:%S"
     date_time_format_for_modified = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/pytrafikverket/trafikverket.py
+++ b/pytrafikverket/trafikverket.py
@@ -7,10 +7,6 @@ import aiohttp
 from lxml import etree
 
 
-def mindebug(str):
-    print(f"** DEBUG: {str}")
-
-
 class FilterOperation(Enum):
     """Contains all field filter operations"""
     equal = "EQ"
@@ -125,7 +121,7 @@ class Trafikverket(object):
         filters_node = etree.SubElement(query_node, "FILTER")
         for filter in filters:
             filter.generate_node(filters_node)
-        mindebug(etree.tostring(root_node, pretty_print=True))
+
         return root_node
 
     async def async_make_request(
@@ -152,7 +148,7 @@ class Trafikverket(object):
                 source = helper.get_text("SOURCE")
                 message = helper.get_text("MESSAGE")
                 raise ValueError("Source: " + source + ", message: " + message)
-            mindebug(content)
+
             return etree.fromstring(content).xpath("/RESPONSE/RESULT/" + objecttype)
 
 

--- a/pytrafikverket/trafikverket.py
+++ b/pytrafikverket/trafikverket.py
@@ -81,7 +81,7 @@ class AndFilter(Filter):
 class Trafikverket(object):
     """Class used to communicate with trafikverket api"""
 
-    _api_url = "http://api.trafikinfo.trafikverket.se/v1.1/data.xml"
+    _api_url = "http://api.trafikinfo.trafikverket.se/v1.3/data.xml"
     date_time_format = "%Y-%m-%dT%H:%M:%S"
     date_time_format_for_modified = "%Y-%m-%dT%H:%M:%S.%fZ"
 

--- a/pytrafikverket/trafikverket.py
+++ b/pytrafikverket/trafikverket.py
@@ -1,3 +1,4 @@
+"""Module for communication with Trafikverket official API."""
 import typing
 from abc import ABCMeta, abstractmethod
 from datetime import datetime
@@ -8,7 +9,8 @@ from lxml import etree
 
 
 class FilterOperation(Enum):
-    """Contains all field filter operations"""
+    """Contains all field filter operations."""
+
     equal = "EQ"
     exists = "EXISTS"
     greater_than = "GT"
@@ -25,12 +27,14 @@ class FilterOperation(Enum):
 
 class SortOrder(Enum):
     """Specifies how rows of data are sorted."""
+
     ascending = "asc"
     decending = "desc"
 
 
 class FieldSort:
-    """What field and how to sort on it"""
+    """What field and how to sort on it."""
+
     def __init__(self, field: str, sort_order: SortOrder):
         self._field = field
         self._sort_order = sort_order
@@ -40,7 +44,8 @@ class FieldSort:
 
 
 class Filter:
-    """Base class for all filters"""
+    """Base class for all filters."""
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -49,7 +54,8 @@ class Filter:
 
 
 class FieldFilter(Filter):
-    """Used to filter on one field"""
+    """Used to filter on one field."""
+
     def __init__(self, operation: FilterOperation, name, value):
         self.operation = operation
         self.name = name
@@ -63,7 +69,8 @@ class FieldFilter(Filter):
 
 
 class OrFilter(Filter):
-    """Used to create a Or filter"""
+    """Used to create a Or filter."""
+
     def __init__(self, filters: typing.List[Filter]):
         self.filters = filters
 
@@ -75,7 +82,8 @@ class OrFilter(Filter):
 
 
 class AndFilter(Filter):
-    """Used to create a And filter"""
+    """Used to create a And filter."""
+
     def __init__(self, filters: typing.List[Filter]):
         self.filters = filters
 
@@ -87,14 +95,14 @@ class AndFilter(Filter):
 
 
 class Trafikverket(object):
-    """Class used to communicate with trafikverket api"""
+    """Class used to communicate with trafikverket api."""
 
     _api_url = "http://api.trafikinfo.trafikverket.se/v1.2/data.xml"
     date_time_format = "%Y-%m-%dT%H:%M:%S"
     date_time_format_for_modified = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     def __init__(self, client_session: aiohttp.ClientSession, api_key: str):
-        """Initialize TrafikInfo object"""
+        """Initialize TrafikInfo object."""
         self._client_session = client_session
         self._api_key = api_key
 
@@ -153,7 +161,8 @@ class Trafikverket(object):
 
 
 class NodeHelper(object):
-    """Helper class to get node content"""
+    """Helper class to get node content."""
+
     def __init__(self, node):
         self._node = node
 

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -34,6 +34,7 @@ class RouteInfo(object):
         name = node_helper.get_text("Name")
         return cls(id, name)
 
+
 class DeviationInfo(object):
     """Contains information about a deviation situation."""
     _required_fields = ["Deviation.Id", "Deviation.Header", "Deviation.EndTime", "Deviation.StartTime",

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -125,7 +125,7 @@ class FerryStop(object):
 
     def get_state(self) -> FerryStopStatus:
         """Retrieve the state of the departure."""
-        if self.deleted:  # Ferrys got no canceled-key, but a deleted
+        if self.deleted:
             return FerryStopStatus.deleted
         return FerryStopStatus.on_time
 
@@ -200,9 +200,6 @@ class TrafikverketFerry(object):
         number_of_stops: int = 1,
     ) -> List[FerryStop]:
         """Enable retreival of next departures."""
-        # ferry_announcements = self.async_get_next_ferry_stops(
-        #     1, from_harbor_name, to_harnbor_name,
-        #     after_time)
 
         date_as_text = after_time.strftime(Trafikverket.date_time_format)
 
@@ -260,14 +257,3 @@ class TrafikverketFerry(object):
 
         return DeviationInfo.from_xml_node(deviation)
 
-    # async def async_get_deviation(self, id: str) -> DeviationInfo:
-    #     """Retreive deviation info from Deviation.Id."""
-    #     deviation = await self._api.async_make_request(
-    #         "Situation",
-    #         DeviationInfo._required_fields,
-    #         [FieldFilter(FilterOperation.equal, "Deviation.Id", id)]
-    #     )
-    #     if len(deviation) == 0:
-    #         raise ValueError("No Deviation found")
-
-    #     return DeviationInfo.from_xml_node(deviation[0])

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -83,7 +83,8 @@ class DeviationInfo(object):
         end_time = node_helper.get_text("Deviation/EndTime")
         icon_id = node_helper.get_text("Deviation/IconId")
         location_desc = node_helper.get_text("Deviation/LocationDescriptor")
-        return cls(id, header, message, start_time, end_time, icon_id, location_desc)
+        return cls(id, header, message, start_time, end_time,
+                   icon_id, location_desc)
 
 
 class FerryStopStatus(Enum):
@@ -220,7 +221,6 @@ class TrafikverketFerry(object):
         number_of_stops: int = 1,
     ) -> List[FerryStop]:
         """Enable retreival of next departures."""
-
         date_as_text = after_time.strftime(Trafikverket.date_time_format)
 
         filters = [
@@ -265,9 +265,7 @@ class TrafikverketFerry(object):
 
     async def async_get_deviation(self, id: str) -> DeviationInfo:
         """Retreive deviation info from Deviation Id."""
-
         filters = [FieldFilter(FilterOperation.equal, "Deviation.Id", id)]
-
         deviations = await self._api.async_make_request(
             "Situation", DeviationInfo._required_fields, filters
         )

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -168,7 +168,7 @@ class TrafikverketFerry(object):
         """Initialize FerryInfo object."""
         self._api = Trafikverket(client_session, api_key)
 
-    async def async_get_route(self, route_name: str) -> RouteInfo:
+    async def async_get_ferry_route(self, route_name: str) -> RouteInfo:
         """Retreive ferry route id based on name."""
         routes = await self._api.async_make_request(
             "FerryRoute",
@@ -182,7 +182,7 @@ class TrafikverketFerry(object):
 
         return RouteInfo.from_xml_node(routes[0])
 
-    async def async_get_route_id(self, route_id: int) -> RouteInfo:
+    async def async_get_ferry_route_id(self, route_id: int) -> RouteInfo:
         """Retreive ferry route id based on routeId."""
         routes = await self._api.async_make_request(
             "FerryRoute",
@@ -196,11 +196,11 @@ class TrafikverketFerry(object):
 
         return RouteInfo.from_xml_node(routes[0])
 
-    async def async_search_routes(self, name: str) -> typing.List[RouteInfo]:
-        """Search for ferry routes."""
+    async def async_search_ferry_routes(self, name: str) -> typing.List[RouteInfo]:
+        """Search for ferry routes based on the route name."""
         routes = await self._api.async_make_request(
             "FerryRoute",
-            ["Name", "Id"],
+            RouteInfo._required_fields,
             [FieldFilter(FilterOperation.like, "Name", name)],
         )
         if len(routes) == 0:

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -12,7 +12,6 @@ from pytrafikverket.trafikverket import (
     NodeHelper,
     SortOrder,
     Trafikverket,
-    mindebug,
 )
 
 
@@ -197,8 +196,8 @@ class TrafikverketFerry(object):
         self,
         from_harbor_name: str,
         to_harnbor_name: str = "",
-        number_of_stops: int = 1,
         after_time: datetime = datetime.now(),
+        number_of_stops: int = 1,
     ) -> List[FerryStop]:
         """Enable retreival of next departures."""
         # ferry_announcements = self.async_get_next_ferry_stops(
@@ -224,7 +223,7 @@ class TrafikverketFerry(object):
             FerryStop._required_fields,
             filters,
             number_of_stops,
-            sorting,
+            sorting
         )
 
         if len(ferry_announcements) == 0:
@@ -242,39 +241,12 @@ class TrafikverketFerry(object):
         after_time: datetime = datetime.now(),
     ) -> FerryStop:
         """Enable retreival of next departure."""
-        date_as_text = after_time.strftime(Trafikverket.date_time_format)
-
-        filters = [
-            FieldFilter(FilterOperation.equal, "FromHarbor.Name", from_harbor_name),
-            FieldFilter(
-                FilterOperation.greater_than_equal, "DepartureTime", date_as_text
-            ),
-        ]
-        if to_harnbor_name:
-            filters.append(
-                FieldFilter(FilterOperation.equal, "ToHarbor.Name", to_harnbor_name)
-            )
-
-        sorting = [FieldSort("DepartureTime", SortOrder.ascending)]
-
-        ferry_announcements = await self._api.async_make_request(
-            "FerryAnnouncement", FerryStop._required_fields, filters, 1, sorting
-        )
-
-        if len(ferry_announcements) == 0:
-            raise ValueError("No FerryAnnouncement found")
-
-        if len(ferry_announcements) > 1:
-            raise ValueError("Multiple FerryAnnouncements found")
-
-        ferry_announcement = ferry_announcements[0]
-
-        return FerryStop.from_xml_node(ferry_announcement)
+        stops = await self.async_get_next_ferry_stops(from_harbor_name, to_harnbor_name, after_time, 1)
+        return stops[0]
 
     async def async_get_deviation(self, id: str) -> DeviationInfo:
         """Retreive deviation info from Deviation Id."""
 
-        mindebug(f"Call get_deviation. {str}")
         filters = [FieldFilter(FilterOperation.equal, "Deviation.Id", id)]
 
         deviations = await self._api.async_make_request(

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -60,7 +60,6 @@ class FerryStopStatus(Enum):
     """Contain the different ferry stop statuses."""
 
     on_time = "scheduled to arrive on schedule"
-    delayed = "delayed"
     canceled = "canceled"
 
 

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -34,27 +34,6 @@ class RouteInfo(object):
         name = node_helper.get_text("Name")
         return cls(id, name)
 
-# class DeviationInfo(object):
-#     """Contains information about a deviation situation."""
-#     _required_fields = ["Deviation.Id", "Deviation.Header", "Deviation.EndTime", "Deviation.StartTime",
-#                         "Deviation.Message", "Deviation.IconId", "Deviation.LocationDescriptor"]
-
-#     def __init__(self, id: str, header: str, message: str):
-#         """Initialize DeviationInfo class."""
-#         self.id = id
-#         self.header = header
-#         self.message = message
-
-#     @classmethod
-#     def from_xml_node(cls, node):
-#         """Map route information in XML data."""
-#         node_helper = NodeHelper(node)
-#         id = node_helper.get_text("Deviation/Id")
-#         header = node_helper.get_text("Deviation/Header")
-#         message = node_helper.get_text("Deviation/Message")
-#         return cls(id, header, message)
-
-
 class DeviationInfo(object):
     """Contains information about a deviation situation."""
     _required_fields = ["Deviation.Id", "Deviation.Header", "Deviation.EndTime", "Deviation.StartTime",

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -1,0 +1,210 @@
+"""Enables retreival of ferry departure information from Trafikverket API."""
+import typing
+from datetime import datetime
+from enum import Enum
+
+import aiohttp
+from pytrafikverket.trafikverket import (
+    FieldFilter,
+    FieldSort,
+    FilterOperation,
+    NodeHelper,
+    OrFilter,
+    SortOrder,
+    Trafikverket,
+)
+
+
+class RouteInfo(object):
+    """Contains information about a Ferryroute."""
+
+    _required_fields = ["Id", "Name"]
+
+    def __init__(self, id: str, name: str):
+        """Initialize RouteInfo class."""
+        self.id = id
+        self.name = name
+
+    @classmethod
+    def from_xml_node(cls, node):
+        """Map route information in XML data."""
+        node_helper = NodeHelper(node)
+        id = node_helper.get_text("Id")
+        name = node_helper.get_text("Name")
+        return cls(id, name)
+
+
+class FerryStopStatus(Enum):
+    """Contain the different ferry stop statuses."""
+
+    on_time = "scheduled to arrive on schedule"
+    delayed = "delayed"
+    canceled = "canceled"
+
+
+class FerryStop(object):
+    """Contain information about a ferry departure."""
+
+    _required_fields = [
+        "Id",
+        "Deleted",
+        "DepartureTime",
+        "Route.Name",
+        "DeviationId",
+        "ModifiedTime",
+        "FromHarbor",
+        "ToHarbor",
+        "Info",
+    ]
+
+    def __init__(
+        self,
+        id,
+        deleted: bool,
+        departure_time: datetime,
+        other_information: typing.List[str],
+        deviation_id: int,
+        modified_time: datetime,
+        from_harbor_name: str,
+        to_harbor_name: str
+    ):
+        """Initialize FerryStop."""
+        self.id = id
+        self.deleted = deleted
+        self.departure_time = departure_time
+        self.other_information = other_information
+        self.deviation_id = deviation_id
+        self.modified_time = modified_time
+        self.from_harbor_name = from_harbor_name
+        self.to_harbor_name = to_harbor_name
+
+    def get_state(self) -> FerryStopStatus:
+        """Retrieve the state of the departure."""
+        if self.deleted:  # Ferrys got no canceled-key, but a deleted
+            return FerryStopStatus.canceled
+        return FerryStopStatus.on_time
+
+    @classmethod
+    def from_xml_node(cls, node):
+        """Map the path in the return XML data."""
+        node_helper = NodeHelper(node)
+        id = node_helper.get_text("Id")
+        deleted = node_helper.get_bool("Deleted")
+        departure_time = node_helper.get_datetime("DepartureTime")
+        other_information = node_helper.get_texts("Info")
+        deviation_id = node_helper.get_texts("DeviationId")
+        modified_time = node_helper.get_datetime_for_modified("ModifiedTime")
+        from_harbor_name = node_helper.get_text("FromHarbor/Name")
+        to_harbor_name = node_helper.get_text("ToHarbor/Name")
+
+        return cls(
+            id, deleted, departure_time, other_information, deviation_id,
+            modified_time, from_harbor_name, to_harbor_name)
+
+
+class TrafikverketFerry(object):
+    """Class used to communicate with trafikverket's ferry route api."""
+
+    def __init__(self, client_session: aiohttp.ClientSession, api_key: str):
+        """Initialize FerryInfo object."""
+        self._api = Trafikverket(client_session, api_key)
+
+    async def async_get_route(self, route_name: str) -> RouteInfo:
+        """Retreive ferry route id based on name."""
+        routes = await self._api.async_make_request(
+            "FerryRoute",
+            RouteInfo._required_fields,
+            [FieldFilter(FilterOperation.equal, "Name", route_name)],
+        )
+        if len(routes) == 0:
+            raise ValueError("Could not find a route with the specified name")
+        if len(routes) > 1:
+            raise ValueError("Found multiple routes with the specified name")
+
+        return RouteInfo.from_xml_node(routes[0])
+
+    async def async_search_routes(self, name: str) -> typing.List[RouteInfo]:
+        """Search for ferry routes."""
+        routes = await self._api.async_make_request(
+            "FerryRoute",
+            ["Name", "Id"],
+            [FieldFilter(FilterOperation.like, "Name", name)],
+        )
+        if len(routes) == 0:
+            raise ValueError("Could not find a ferry route with the specified name")
+
+        result = [RouteInfo] * 0
+
+        for route in routes:
+            result.append(RouteInfo.from_xml_node(route))
+
+        return result
+
+    # async def async_get_ferry_stop(
+    #         self,
+    #         from_harbor_name: str,
+    #         to_harbor_name: str = "",
+    #         ) -> FerryStop:
+    #     """Retrieve the ferry stop."""
+    #     date_as_text = departure_time.strftime(Trafikverket.date_time_format)
+
+    #     filters = [
+    #         # FieldFilter(FilterOperation.equal,
+    #         #             "ActivityType", "Avgang"),
+    #         FieldFilter(FilterOperation.equal,
+    #                     "FromHarbor.Name",
+    #                     from_harbor_name),
+    #         FieldFilter(FilterOperation.equal,
+    #                     "FromHarbor.Name",
+    #                     from_harbor_name),
+
+    #         FieldFilter(FilterOperation.equal,
+    #                     "DepartureTime",
+    #                     date_as_text)]
+
+    #     ferry_announcements = await self._api.async_make_request(
+    #         "FerryAnnouncement",
+    #         FerryStop._required_fields,
+    #         filters)
+
+    #     if len(ferry_announcements) == 0:
+    #         raise ValueError("No FerryAnnouncement found")
+
+    #     if len(ferry_announcements) > 1:
+    #         raise ValueError("Multiple FerryAnnouncements found")
+
+    #     ferry_announcement = ferry_announcements[0]
+    #     return FerryStop.from_xml_node(ferry_announcement)
+
+    async def async_get_next_ferry_stop(
+        self,
+        from_harbor_name: str,
+        to_harnbor_name: str = "",
+        after_time: datetime = datetime.now(),
+    ) -> FerryStop:
+        """Enable retreival of next departure."""
+        date_as_text = after_time.strftime(Trafikverket.date_time_format)
+
+        filters = [
+            FieldFilter(FilterOperation.equal,
+                        "FromHarbor.Name", from_harbor_name),
+            FieldFilter(FilterOperation.greater_than_equal,
+                        "DepartureTime", date_as_text),
+        ]
+        if to_harnbor_name:
+            filters.append(FieldFilter(FilterOperation.equal,
+                           "ToHarbor.Name", to_harnbor_name))
+
+        sorting = [FieldSort("DepartureTime", SortOrder.ascending)]
+        ferry_announcements = await self._api.async_make_request(
+            "FerryAnnouncement", FerryStop._required_fields, filters, 1, sorting)
+
+        if len(ferry_announcements) == 0:
+            raise ValueError("No FerryAnnouncement found")
+
+        if len(ferry_announcements) > 1:
+            raise ValueError("Multiple FerryAnnouncement found")
+
+        ferry_announcement = ferry_announcements[0]
+
+        return FerryStop.from_xml_node(ferry_announcement)

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -111,7 +111,7 @@ class FerryStop(object):
         deviation_id: str,
         modified_time: datetime,
         from_harbor_name: str,
-        to_harbor_name: str
+        to_harbor_name: str,
     ):
         """Initialize FerryStop."""
         self.id = id
@@ -143,9 +143,15 @@ class FerryStop(object):
         to_harbor_name = node_helper.get_text("ToHarbor/Name")
 
         return cls(
-            id, deleted, departure_time, other_information,
-            deviation_id, modified_time,
-            from_harbor_name, to_harbor_name)
+            id,
+            deleted,
+            departure_time,
+            other_information,
+            deviation_id,
+            modified_time,
+            from_harbor_name,
+            to_harbor_name,
+        )
 
     def print(self):
         """Prints some class variables"""
@@ -220,7 +226,7 @@ class TrafikverketFerry(object):
             FerryStop._required_fields,
             filters,
             number_of_stops,
-            sorting
+            sorting,
         )
 
         if len(ferry_announcements) == 0:
@@ -238,7 +244,9 @@ class TrafikverketFerry(object):
         after_time: datetime = datetime.now(),
     ) -> FerryStop:
         """Enable retreival of next departure."""
-        stops = await self.async_get_next_ferry_stops(from_harbor_name, to_harnbor_name, after_time, 1)
+        stops = await self.async_get_next_ferry_stops(
+            from_harbor_name, to_harnbor_name, after_time, 1
+        )
         return stops[0]
 
     async def async_get_deviation(self, id: str) -> DeviationInfo:
@@ -252,8 +260,8 @@ class TrafikverketFerry(object):
 
         if len(deviations) == 0:
             raise ValueError("No Deviation found")
+        if len(deviations) > 1:
+            raise ValueError("Multiple Deviations found")
 
         deviation = deviations[0]
-
         return DeviationInfo.from_xml_node(deviation)
-

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -21,7 +21,7 @@ class RouteInfo(object):
 
     _required_fields = ["Id", "Name", "Shortname", "Type.Name"]
 
-    def __init__(self, id: int, name: str, short_name: str, route_type: str):
+    def __init__(self, id: str, name: str, short_name: str, route_type: str):
         """Initialize RouteInfo class."""
         self.id = id
         self.name = name

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -245,7 +245,7 @@ class TrafikverketFerry(object):
 
         ferry_announcements = await self._api.async_make_request(
                                 "FerryAnnouncement",
-                                FerryStop._required_fields, 
+                                FerryStop._required_fields,
                                 filters,
                                 1, sorting)
 
@@ -258,7 +258,6 @@ class TrafikverketFerry(object):
         ferry_announcement = ferry_announcements[0]
 
         return FerryStop.from_xml_node(ferry_announcement)
-
 
     async def async_get_deviation(self, id: str) -> DeviationInfo:
         filters = [
@@ -274,7 +273,6 @@ class TrafikverketFerry(object):
         deviation = deviations[0]
 
         return DeviationInfo.from_xml_node(deviation)
-
 
     # async def async_get_deviation(self, id: str) -> DeviationInfo:
     #     """Retreive deviation info from Deviation.Id."""

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -1,4 +1,5 @@
 """Enables retreival of ferry departure information from Trafikverket API."""
+
 import typing
 from datetime import datetime
 from enum import Enum
@@ -16,7 +17,7 @@ from pytrafikverket.trafikverket import (
 
 
 class RouteInfo(object):
-    """Contains information about a Ferryroute. """
+    """Contains information about a FerryRoute."""
 
     _required_fields = ["Id", "Name"]
 
@@ -35,7 +36,7 @@ class RouteInfo(object):
 
 
 class DeviationInfo(object):
-    """Contains information about a deviation situation."""
+    """Contains information about a Situation/Deviation."""
 
     _required_fields = [
         "Deviation.Id",
@@ -152,12 +153,6 @@ class FerryStop(object):
             from_harbor_name,
             to_harbor_name,
         )
-
-    def print(self):
-        """Prints some class variables"""
-        print(f"time: {self.departure_time}")
-        print(f"from: {self.from_harbor_name}")
-        print(f"to: {self.to_harbor_name}")
 
 
 class TrafikverketFerry(object):

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -121,11 +121,10 @@ class TrafikverketTrain(object):
     async def async_get_train_station(self, location_name: str) -> StationInfo:
         """Retreive train station id based on name."""
         train_stations = await self._api.async_make_request(
-                                    "TrainStation",
-                                    StationInfo._required_fields,
-                                    [FieldFilter(FilterOperation.equal,
-                                                 "AdvertisedLocationName",
-                                                 location_name)])
+            "TrainStation",
+            StationInfo._required_fields,
+            [FieldFilter(FilterOperation.equal,
+                         "AdvertisedLocationName", location_name)])
         if len(train_stations) == 0:
             raise ValueError(
                 "Could not find a station with the specified name")
@@ -139,12 +138,10 @@ class TrafikverketTrain(object):
             self, location_name: str) -> typing.List[StationInfo]:
         """Search for train stations."""
         train_stations = await self._api.async_make_request(
-                                    "TrainStation",
-                                    ["AdvertisedLocationName",
-                                     "LocationSignature"],
-                                    [FieldFilter(FilterOperation.like,
-                                                 "AdvertisedLocationName",
-                                                 location_name)])
+            "TrainStation",
+            ["AdvertisedLocationName", "LocationSignature"],
+            [FieldFilter(FilterOperation.like,
+                         "AdvertisedLocationName", location_name)])
         if len(train_stations) == 0:
             raise ValueError(
                 "Could not find a station with the specified name")
@@ -157,9 +154,8 @@ class TrafikverketTrain(object):
         return result
 
     async def async_get_train_stop(
-                self, from_station: StationInfo,
-                to_station: StationInfo,
-                time_at_location: datetime) -> TrainStop:
+            self, from_station: StationInfo,
+            to_station: StationInfo, time_at_location: datetime) -> TrainStop:
         """Retrieve the train stop."""
         date_as_text = time_at_location.strftime(Trafikverket.date_time_format)
 
@@ -181,9 +177,7 @@ class TrafikverketTrain(object):
                                          to_station.signature)])]
 
         train_announcements = await self._api.async_make_request(
-                                        "TrainAnnouncement",
-                                        TrainStop._required_fields,
-                                        filters)
+            "TrainAnnouncement", TrainStop._required_fields, filters)
 
         if len(train_announcements) == 0:
             raise ValueError("No TrainAnnouncement found")
@@ -222,9 +216,7 @@ class TrafikverketTrain(object):
 
         sorting = [FieldSort("AdvertisedTimeAtLocation", SortOrder.ascending)]
         train_announcements = await self._api.async_make_request(
-                                "TrainAnnouncement",
-                                TrainStop._required_fields,
-                                filters, 1, sorting)
+            "TrainAnnouncement", TrainStop._required_fields, filters, 1, sorting)
 
         if len(train_announcements) == 0:
             raise ValueError("No TrainAnnouncement found")

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -41,8 +41,8 @@ class TrainStop(object):
     """Contain information about a train stop."""
 
     _required_fields = ["ActivityId", "Canceled", "AdvertisedTimeAtLocation",
-                       "EstimatedTimeAtLocation", "TimeAtLocation",
-                       "OtherInformation", "Deviation", "ModifiedTime"]
+                        "EstimatedTimeAtLocation", "TimeAtLocation",
+                        "OtherInformation", "Deviation", "ModifiedTime"]
 
     def __init__(self, id, canceled: bool,
                  advertised_time_at_location: datetime,

--- a/pytrafikverket/trafikverket_weather.py
+++ b/pytrafikverket/trafikverket_weather.py
@@ -80,10 +80,9 @@ class TrafikverketWeather(object):
             self, location_name: str) -> WeatherStationInfo:
         """Retrieve weather from API."""
         weather_stations = await self._api.async_make_request(
-                            "WeatherStation",
-                            WeatherStationInfo._required_fields,
-                            [FieldFilter(FilterOperation.equal,
-                                         "Name", location_name)])
+            "WeatherStation",
+            WeatherStationInfo._required_fields,
+            [FieldFilter(FilterOperation.equal, "Name", location_name)])
         if len(weather_stations) == 0:
             raise ValueError(
                 "Could not find a weather station with the specified name")

--- a/pytrafikverket/trafikverket_weather.py
+++ b/pytrafikverket/trafikverket_weather.py
@@ -9,18 +9,18 @@ class WeatherStationInfo(object):
     """Fetch Weather data from specified weather station."""
 
     _required_fields = ["Name",
-                       "Id",
-                       "Measurement.Road.Temp",
-                       "Measurement.Air.Temp",
-                       "Measurement.Air.RelativeHumidity",
-                       "Measurement.Precipitation.Type",
-                       "Measurement.Wind.Direction",
-                       "Measurement.Wind.DirectionText",
-                       "Measurement.Wind.Force",
-                       "Active",
-                       "Measurement.MeasureTime",
-                       "Measurement.Precipitation.Amount",
-                       "Measurement.Precipitation.AmountName"]
+                        "Id",
+                        "Measurement.Road.Temp",
+                        "Measurement.Air.Temp",
+                        "Measurement.Air.RelativeHumidity",
+                        "Measurement.Precipitation.Type",
+                        "Measurement.Wind.Direction",
+                        "Measurement.Wind.DirectionText",
+                        "Measurement.Wind.Force",
+                        "Active",
+                        "Measurement.MeasureTime",
+                        "Measurement.Precipitation.Amount",
+                        "Measurement.Precipitation.AmountName"]
 
     def __init__(self, station_name: str, station_id: str, road_temp: float,
                  air_temp: float, humidity: float, precipitationtype: str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ aiohttp==3.1.0
 async-timeout==2.0.1
 attrs==17.4.0
 chardet==3.0.4
-idna==2.6
-idna-ssl==1.0.1
+idna>=2.6
+idna-ssl>=1.0.1
 lxml>=4.2.1
 multidict==4.1.0
 pip==9.0.3

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-""" Setup for pytrafikverket """
+"""Setup for pytrafikverket."""
 
 from setuptools import setup
 
@@ -6,15 +6,13 @@ setup(
     name="pytrafikverket",
     version="0.1.5.9",
     description="api for trafikverket in sweden",
-    url='https://github.com/AnderssonPeter/pytrafikverket',
+    url="https://github.com/AnderssonPeter/pytrafikverket",
     author="Peter Andersson",
     license="MIT",
     install_requires=["aiohttp", "async-timeout", "lxml"],
     packages=["pytrafikverket"],
     zip_safe=True,
     entry_point={
-        "console_scripts": [
-            "pytrafikverket=pytrafikverket.pytrafikverket:main"
-            ]
-        }
-    )
+        "console_scripts": ["pytrafikverket=pytrafikverket.pytrafikverket:main"]
+    },
+)


### PR DESCRIPTION
Added support for ferry information. 
I have tried to keep the same formats and names as much as possible, even though the ferry departures differ from trains.

CLI-example:
`-key [api_key_here] -method get-next-ferry-stop -from-harbor "Ekerö"`
`-key [api_key_here] -method get-next-ferry-stop -from-harbor "Furusund" -date-time "2019-12-24T00:00:00"`
