### PR TITLE
Updated to support Trafikverket API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ from datetime import datetime
 async def main(loop):
 	async with aiohttp.ClientSession(loop=loop) as session:
 		train_api = TrafikverketTrain(session, "api_key_here")
-		stations = await train_api.search_train_stations("kristianstad")
+		stations = await train_api.async_search_train_stations("kristianstad")
 		for station in stations:
 			print(station.name + " " + station.signature)
 
-		from_station = await train_api.get_train_station("Sölvesborg")
-		to_station = await train_api.get_train_station("Kristianstad C")
+		from_station = await train_api.async_get_train_station("Sölvesborg")
+		to_station = await train_api.async_get_train_station("Kristianstad C")
 		print("from_station_signature: " + from_station.signature)
 		print("to_station_signature:   " + to_station.signature)
-		train_stop = await train_api.get_train_stop(from_station, to_station, datetime(2017, 5, 15, 12, 57));
+		train_stop = await train_api.async_get_train_stop(from_station, to_station, datetime(2022, 4, 11, 12, 57));
 		print(train_stop.get_state())
 
 loop = asyncio.get_event_loop()

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -19,7 +19,7 @@ GET_WEATHER = "get-weather"
 GET_FERRY_ROUTE = "get-ferry-route"
 SEARCH_FOR_FERRY_ROUTE = "search-for-ferry-route"
 GET_NEXT_FERRY_STOP = "get-next-ferry-stop"
-
+DATE_TIME_INPUT = "%Y-%m-%dT%H:%M:%S"
 
 async def async_main(loop):
     """Set up function to handle input and get data to present."""
@@ -70,7 +70,7 @@ async def async_main(loop):
                 print("from_station_signature: " + from_station.signature)
                 print("to_station_signature:   " + to_station.signature)
 
-                time = datetime.strptime(args.date_time, Trafikverket.date_time_format)
+                time = datetime.strptime(args.date_time, DATE_TIME_INPUT)
 
                 train_stop = await train_api.async_get_train_stop(
                     from_station, to_station, time
@@ -87,7 +87,7 @@ async def async_main(loop):
 
                 if args.date_time is not None:
                     time = datetime.strptime(
-                        args.date_time, Trafikverket.date_time_format
+                        args.date_time, DATE_TIME_INPUT
                     )
                 else:
                     time = datetime.now()
@@ -130,7 +130,7 @@ async def async_main(loop):
                     )
                 if args.date_time is not None:
                     time = datetime.strptime(
-                        args.date_time, Trafikverket.date_time_format
+                        args.date_time, DATE_TIME_INPUT
                     )
                 else:
                     time = datetime.now()

--- a/pytrafikverket/trafikverket.py
+++ b/pytrafikverket/trafikverket.py
@@ -106,8 +106,8 @@ class AndFilter(Filter):
 class Trafikverket(object):
     """Class used to communicate with trafikverket api."""
 
-    _api_url = "http://api.trafikinfo.trafikverket.se/v1.2/data.xml"
-    date_time_format = "%Y-%m-%dT%H:%M:%S"
+    _api_url = "https://api.trafikinfo.trafikverket.se/v2/data.xml"
+    date_time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
     date_time_format_for_modified = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     def __init__(self, client_session: aiohttp.ClientSession, api_key: str):
@@ -118,6 +118,7 @@ class Trafikverket(object):
     def _generate_request_data(
         self,
         objecttype: str,
+        schemaversion: str,
         includes: typing.List[str],
         filters: typing.List[Filter],
         limit: int = None,
@@ -128,6 +129,7 @@ class Trafikverket(object):
         login_node.attrib["authenticationkey"] = self._api_key
         query_node = etree.SubElement(root_node, "QUERY")
         query_node.attrib["objecttype"] = objecttype
+        query_node.attrib["schemaversion"] = schemaversion
         if limit is not None:
             query_node.attrib["limit"] = str(limit)
         if sorting is not None and len(sorting) > 0:
@@ -144,6 +146,7 @@ class Trafikverket(object):
     async def async_make_request(
         self,
         objecttype: str,
+        schemaversion: str,
         includes: typing.List[str],
         filters: typing.List[Filter],
         limit: int = None,
@@ -151,7 +154,7 @@ class Trafikverket(object):
     ):
         """Send request to trafikverket api and return a element node."""
         request_data = self._generate_request_data(
-            objecttype, includes, filters, limit, sorting
+            objecttype, schemaversion, includes, filters, limit, sorting
         )
         request_data_text = etree.tostring(request_data, pretty_print=False)
         headers = {"content-type": "text/xml"}

--- a/pytrafikverket/trafikverket_ferry.py
+++ b/pytrafikverket/trafikverket_ferry.py
@@ -172,6 +172,7 @@ class TrafikverketFerry(object):
         """Retreive ferry route id based on name."""
         routes = await self._api.async_make_request(
             "FerryRoute",
+            "1.2",
             RouteInfo._required_fields,
             [FieldFilter(FilterOperation.equal, "Name", route_name)],
         )
@@ -186,6 +187,7 @@ class TrafikverketFerry(object):
         """Retreive ferry route id based on routeId."""
         routes = await self._api.async_make_request(
             "FerryRoute",
+            "1.2",
             RouteInfo._required_fields,
             [FieldFilter(FilterOperation.equal, "Id", str(route_id))],
         )
@@ -200,6 +202,7 @@ class TrafikverketFerry(object):
         """Search for ferry routes based on the route name."""
         routes = await self._api.async_make_request(
             "FerryRoute",
+            "1.2",
             RouteInfo._required_fields,
             [FieldFilter(FilterOperation.like, "Name", name)],
         )
@@ -237,6 +240,7 @@ class TrafikverketFerry(object):
         sorting = [FieldSort("DepartureTime", SortOrder.ascending)]
         ferry_announcements = await self._api.async_make_request(
             "FerryAnnouncement",
+            "1.2",
             FerryStop._required_fields,
             filters,
             number_of_stops,
@@ -267,7 +271,7 @@ class TrafikverketFerry(object):
         """Retreive deviation info from Deviation Id."""
         filters = [FieldFilter(FilterOperation.equal, "Deviation.Id", id)]
         deviations = await self._api.async_make_request(
-            "Situation", DeviationInfo._required_fields, filters
+            "Situation", "1.5", DeviationInfo._required_fields, filters
         )
 
         if len(deviations) == 0:

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -126,6 +126,7 @@ class TrafikverketTrain(object):
         """Retreive train station id based on name."""
         train_stations = await self._api.async_make_request(
             "TrainStation",
+            "1.4",
             StationInfo._required_fields,
             [FieldFilter(FilterOperation.equal,
                          "AdvertisedLocationName", location_name),
@@ -144,6 +145,7 @@ class TrafikverketTrain(object):
         """Search for train stations."""
         train_stations = await self._api.async_make_request(
             "TrainStation",
+            "1.4",
             ["AdvertisedLocationName", "LocationSignature",
              "Advertised", "Deleted"],
             [FieldFilter(FilterOperation.like,
@@ -184,7 +186,7 @@ class TrafikverketTrain(object):
                                          to_station.signature)])]
 
         train_announcements = await self._api.async_make_request(
-            "TrainAnnouncement", TrainStop._required_fields, filters)
+            "TrainAnnouncement", "1.6", TrainStop._required_fields, filters)
 
         if len(train_announcements) == 0:
             raise ValueError("No TrainAnnouncement found")
@@ -224,6 +226,7 @@ class TrafikverketTrain(object):
         sorting = [FieldSort("AdvertisedTimeAtLocation", SortOrder.ascending)]
         train_announcements = await self._api.async_make_request(
             "TrainAnnouncement",
+            "1.6",
             TrainStop._required_fields,
             filters,
             1,

--- a/pytrafikverket/trafikverket_weather.py
+++ b/pytrafikverket/trafikverket_weather.py
@@ -84,6 +84,7 @@ class TrafikverketWeather(object):
         """Retrieve weather from API."""
         weather_stations = await self._api.async_make_request(
             "WeatherStation",
+            "1.0",
             WeatherStationInfo._required_fields,
             [FieldFilter(FilterOperation.equal, "Name", location_name)])
         if len(weather_stations) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 aiohttp==3.7.4
-async-timeout==2.0.1
+async-timeout>3.0.0
 attrs==17.4.0
 chardet==3.0.4
 idna>=2.6
 idna-ssl>=1.0.1
 lxml>=4.2.1
-multidict==4.1.0
+multidict==4.5.0
 pip==21.1
 setuptools==39.0.1
 yarl==1.1.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 setup(
     name="pytrafikverket",
     version="0.1.6.2",
-    description="Retreive values from public API at trafikverket in sweden.",
+    description="Retreive values from public API at the Swedish Transport Administration (Trafikverket).",
     url="https://github.com/endor-force/pytrafikverket",
     author="Peter Andersson, Jonas Karlsson",
     license="MIT",


### PR DESCRIPTION
Older versions of the API from Trafikverket will shut down this summer:
https://api.trafikinfo.trafikverket.se/DynamicContent/ContentDetails/61c33a304f02c133ec325ef2

So here is a PR with some updates to get on the latest version

* Timestamps in v2 have more precision, so I split that to keep the same pytrafikverket interface as before
* Added support for schemaversion, and added the latest schemaversion to all apis used
* Updated the readme to include the async-change made previously

I didn't know your versioning strategy so I leave that to the maintainers to update