### PR TITLE
Implement filtering of [non-]canceled trains

### DIFF
--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -48,8 +48,7 @@ async def async_main(loop):
         parser.add_argument("-from-harbor", type=str)
         parser.add_argument("-to-harbor", type=str)
         parser.add_argument("-train-product", type=str)
-        parser.add_argument("--train-canceled", action=argparse.BooleanOptionalAction)
-        parser.add_argument("--train-not-canceled", action=argparse.BooleanOptionalAction)
+        parser.add_argument("--exclude-canceled-trains", action=argparse.BooleanOptionalAction, default=False)
 
         args = parser.parse_args()
 
@@ -57,12 +56,6 @@ async def async_main(loop):
         weather_api = TrafikverketWeather(session, args.key)
         ferry_api = TrafikverketFerry(session, args.key)
 
-        if args.train_canceled:
-            canceled = True
-        elif args.train_not_canceled:
-            canceled = False
-        else:
-            canceled = None
 
         with async_timeout.timeout(10):
             if args.method == SEARCH_FOR_STATION:
@@ -88,7 +81,7 @@ async def async_main(loop):
                     to_station,
                     time,
                     product_description=args.train_product,
-                    canceled=canceled,
+                    exclude_canceled=args.exclude_canceled_trains,
                 )
                 print_values(train_stop)
 
@@ -111,7 +104,7 @@ async def async_main(loop):
                     to_station,
                     time,
                     product_description=args.train_product,
-                    canceled=canceled,
+                    exclude_canceled=args.exclude_canceled_trains,
                 )
                 print_values(train_stop)
 

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -48,12 +48,22 @@ async def async_main(loop):
         parser.add_argument("-from-harbor", type=str)
         parser.add_argument("-to-harbor", type=str)
         parser.add_argument("-train-product", type=str)
+        parser.add_argument("--train-canceled", action=argparse.BooleanOptionalAction)
+        parser.add_argument("--train-not-canceled", action=argparse.BooleanOptionalAction)
 
         args = parser.parse_args()
 
         train_api = TrafikverketTrain(session, args.key)
         weather_api = TrafikverketWeather(session, args.key)
         ferry_api = TrafikverketFerry(session, args.key)
+
+        if args.train_canceled:
+            canceled = True
+        elif args.train_not_canceled:
+            canceled = False
+        else:
+            canceled = None
+
         with async_timeout.timeout(10):
             if args.method == SEARCH_FOR_STATION:
                 if args.station is None:
@@ -74,7 +84,11 @@ async def async_main(loop):
                 time = datetime.strptime(args.date_time, DATE_TIME_INPUT)
 
                 train_stop = await train_api.async_get_train_stop(
-                    from_station, to_station, time, product_description=args.train_product
+                    from_station,
+                    to_station,
+                    time,
+                    product_description=args.train_product,
+                    canceled=canceled,
                 )
                 print_values(train_stop)
 
@@ -93,7 +107,11 @@ async def async_main(loop):
                 else:
                     time = datetime.now()
                 train_stop = await train_api.async_get_next_train_stop(
-                    from_station, to_station, time, product_description=args.train_product
+                    from_station,
+                    to_station,
+                    time,
+                    product_description=args.train_product,
+                    canceled=canceled,
                 )
                 print_values(train_stop)
 

--- a/pytrafikverket/__main__.py
+++ b/pytrafikverket/__main__.py
@@ -48,7 +48,7 @@ async def async_main(loop):
         parser.add_argument("-from-harbor", type=str)
         parser.add_argument("-to-harbor", type=str)
         parser.add_argument("-train-product", type=str)
-        parser.add_argument("--exclude-canceled-trains", action=argparse.BooleanOptionalAction, default=False)
+        parser.add_argument("-exclude-canceled-trains", action=argparse.BooleanOptionalAction, default=False)
 
         args = parser.parse_args()
 

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -204,7 +204,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         time_at_location: datetime,
         product_description: typing.Optional[str] = None,
-        exclude_canceled: typing.Optional[bool] = False,
+        exclude_canceled: bool = False,
     ) -> TrainStop:
         """Retrieve the train stop."""
         date_as_text = time_at_location.strftime(Trafikverket.date_time_format)
@@ -270,7 +270,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         after_time: datetime,
         product_description: typing.Optional[str] = None,
-        exclude_canceled: typing.Optional[bool] = False,
+        exclude_canceled: bool = False,
     ) -> TrainStop:
         """Enable retreival of next departure."""
         date_as_text = after_time.strftime(Trafikverket.date_time_format)

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -204,6 +204,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         time_at_location: datetime,
         product_description: typing.Optional[str] = None,
+        canceled: typing.Optional[bool] = None,
     ) -> TrainStop:
         """Retrieve the train stop."""
         date_as_text = time_at_location.strftime(Trafikverket.date_time_format)
@@ -241,6 +242,15 @@ class TrafikverketTrain(object):
                 )
             )
 
+        if canceled is not None:
+            filters.append(
+                FieldFilter(
+                    FilterOperation.equal,
+                    "Canceled",
+                    str(canceled).lower()
+                )
+            )
+
         train_announcements = await self._api.async_make_request(
             "TrainAnnouncement", "1.6", TrainStop._required_fields, filters
         )
@@ -260,6 +270,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         after_time: datetime,
         product_description: typing.Optional[str] = None,
+        canceled: typing.Optional[bool] = None,
     ) -> TrainStop:
         """Enable retreival of next departure."""
         date_as_text = after_time.strftime(Trafikverket.date_time_format)
@@ -296,6 +307,15 @@ class TrafikverketTrain(object):
                     FilterOperation.equal,
                     "ProductInformation.Description",
                     product_description,
+                )
+            )
+
+        if canceled is not None:
+            filters.append(
+                FieldFilter(
+                    FilterOperation.equal,
+                    "Canceled",
+                    str(canceled).lower()
                 )
             )
 

--- a/pytrafikverket/trafikverket_train.py
+++ b/pytrafikverket/trafikverket_train.py
@@ -204,7 +204,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         time_at_location: datetime,
         product_description: typing.Optional[str] = None,
-        canceled: typing.Optional[bool] = None,
+        exclude_canceled: typing.Optional[bool] = False,
     ) -> TrainStop:
         """Retrieve the train stop."""
         date_as_text = time_at_location.strftime(Trafikverket.date_time_format)
@@ -242,12 +242,12 @@ class TrafikverketTrain(object):
                 )
             )
 
-        if canceled is not None:
+        if exclude_canceled:
             filters.append(
                 FieldFilter(
                     FilterOperation.equal,
                     "Canceled",
-                    str(canceled).lower()
+                    "false"
                 )
             )
 
@@ -270,7 +270,7 @@ class TrafikverketTrain(object):
         to_station: StationInfo,
         after_time: datetime,
         product_description: typing.Optional[str] = None,
-        canceled: typing.Optional[bool] = None,
+        exclude_canceled: typing.Optional[bool] = False,
     ) -> TrainStop:
         """Enable retreival of next departure."""
         date_as_text = after_time.strftime(Trafikverket.date_time_format)
@@ -310,12 +310,12 @@ class TrafikverketTrain(object):
                 )
             )
 
-        if canceled is not None:
+        if exclude_canceled:
             filters.append(
                 FieldFilter(
                     FilterOperation.equal,
                     "Canceled",
-                    str(canceled).lower()
+                    "false"
                 )
             )
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="pytrafikverket",
-    version="0.2.2",
+    version="0.2.3",
     description="Retreive values from public API at the Swedish Transport Administration (Trafikverket).",
     url="https://github.com/endor-force/pytrafikverket",
     author="Peter Andersson, Jonas Karlsson",


### PR DESCRIPTION
- Add arguments `--train-canceled` and `--train-not-canceled` to CLI app.
- Implement optional `canceled` argument for filtering in `async_get_train_stop(...)` and `async_get_next_train_stop(...)`

This could possible be implemented for ferries as well, but they do not have a "Canceled" property. Instead they have something called "Deleted", but it is unclear what it does.